### PR TITLE
fix: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4217,7 +4217,7 @@ Result (`boolean`): Represents whether the operation was successful or not.
 
 ### Join or leave a group
 
-Send a message from a user to a channel (chat or group).
+This API will join or remove a user given by `userID` to a channel (chat or group) given by `channelID`.
 
 ```tsx
 joinGroup(userID: UUID, channelID: UUID): boolean


### PR DESCRIPTION
# Changelog

In API design for WhatsApp _Join or leave a group_ has the same description as _Send message_ so I changed it to: 
```
This API will join or remove a user given by `userID` to a channel (chat or group) given by `channelID`
```
btw I want to thank you for the course, it has been so helpful :)