### PR TITLE
[Fix] DNS Flow Description 

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ DNS lookup involves the following eight steps:
 2. The resolver then recursively queries a DNS root nameserver.
 3. The root server responds to the resolver with the address of a Top-Level Domain (TLD).
 4. The resolver then makes a request to the `.com` TLD.
-5. The TLD server then responds with the IP address of the domain's nameserver, [example.com](http://example.com).
-6. Lastly, the recursive resolver sends a query to the domain's nameserver.
+5. The TLD server then responds to the query by pointing the resolver to the authoritative nameservers for example.com, [example.com](http://example.com).
+6. Lastly, the recursive resolver sends a query to the authoritative nameserver of the domain example.com
 7. The IP address for [example.com](http://example.com) is then returned to the resolver from the nameserver.
 8. The DNS resolver then responds to the web browser with the IP address of the domain requested initially.
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ DNS lookup involves the following eight steps:
 3. The root server responds to the resolver with the address of a Top-Level Domain (TLD).
 4. The resolver then makes a request to the `.com` TLD.
 5. The TLD server then responds to the query by pointing the resolver to the authoritative nameservers for example.com, [example.com](http://example.com).
-6. Lastly, the recursive resolver sends a query to the authoritative nameserver of the domain example.com
+6. Lastly, the recursive resolver sends a query to the authoritative nameserver of [example.com](http://example.com)
 7. The IP address for [example.com](http://example.com) is then returned to the resolver from the nameserver.
 8. The DNS resolver then responds to the web browser with the IP address of the domain requested initially.
 


### PR DESCRIPTION
Change in the DNS Flow description to add the work of authoritative server as shown by arrow 6,7. 

Making this change since

A TLD nameserver is responsible for managing the top-level domain (TLD) portion of the DNS hierarchy. It holds information about the authoritative nameservers for domains that fall under its TLD.

An authoritative nameserver holds the actual DNS records (A, AAAA, MX, CNAME, etc.) for a specific domain. It provides the final answer for queries related to the domain name it manages.
