### PR TITLE
fix: clarify write-around cache language

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Where write directly goes to the database or permanent storage, bypassing the ca
 
 **Pro**: This may reduce latency.
 
-**Con**: It increases cache misses because the cache system has to read the information from the database in case of a cache miss. As a result, this can lead to higher read latency in the case of applications that write and re-read the information quickly. Read happen from slower back-end storage and experiences higher latency.
+**Con**: It increases cache misses because the cache system has to read the information from the database in case of a cache miss. As a result, this can lead to higher read latency in the case of applications that write and re-read the information quickly. Reads come from slower back-end storage and therefore experience higher latency.
 
 ### Write-back cache
 


### PR DESCRIPTION
Fixes a couple typos and makes the wording around why write-around caches can increase latency easier to understand.
