### PR TITLE
Remove wrong parameter in description in follow/unfollow API in design Twitter section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4582,8 +4582,6 @@ Follower ID (`UUID`): ID of the current user.
 
 Followee ID (`UUID`): ID of the user we want to follow or unfollow.
 
-Media URL (`string`): URL of the attached media _(optional)_.
-
 **Returns**
 
 Result (`boolean`): Represents whether the operation was successful or not.


### PR DESCRIPTION
# Changelog

In chapter 5, Twitter section, inside the `API design`, the `Follow or unfollow a user`, there is an extract argument `Media URL` which should not appear. It looks like a copy-and-paste error.