### PR TITLE
Link 'SQL vs NoSQL databases' indexing part to 'Indexes' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,7 @@ One of the simplest types of NoSQL databases, key-value databases save data as a
 
 - Basic CRUD
 - Values can't be filtered
-- Lacks indexing and scanning capabilities
+- Lacks [indexing](#indexes) and scanning capabilities
 - Not optimized for complex queries
 
 **Examples**


### PR DESCRIPTION
# Changelog

Linked the term “index” in “Lookups by index are very fast” (under reasons to choose SQL in the ‘SQL vs NoSQL databases’ section of chapter ||) to the ‘Indexes’ section. Readers may not be familiar with indexes when they reach this part. While it’s okay to search, the book covers indexes later, so this link improves flow when reading in order.