### PR TITLE
Clarify why server changes are expensive in hash-based sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1767,7 +1767,7 @@ There are a large number of criteria available for data partitioning. Some most 
 
 This strategy divides the rows into different partitions based on a hashing algorithm rather than grouping database rows based on continuous indexes.
 
-The disadvantage of this method is that dynamically adding/removing database servers becomes expensive.
+The disadvantage of this method is that dynamically adding/removing database servers becomes expensive. This expense arises because a key's shard is often determined by a formula like `hash(key) % number_of_servers`. When a server is added or removed, `number_of_servers` changes, altering the result of the formula for nearly every key and requiring a massive rebalancing of data across the system.
 
 ### List-Based
 


### PR DESCRIPTION
# Changelog

I was reading through the section on Hash-Based partitioning and found it really clear. However, when I got to the line:

> The disadvantage of this method is that dynamically adding/removing database servers becomes expensive.

I had a "wait, why?" moment. For a second, it wasn't immediately obvious why that would be the case. After thinking it through, I realized it's because the common hashing approach (like `hash(key) % number_of_servers`) is fundamentally tied to the total server count.

I believe a quick explanatory sentence would be a great addition for future readers, helping the concept "click" without requiring them to pause and work it out themselves.
I've added a concise explanation to address this. Let me know what you think!
